### PR TITLE
build: add major, minor and patch outputs.

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -71,7 +71,11 @@ jobs:
       - name: Verify patch bump
         if: >
           steps.patch_bumper.outputs.new_version != '1.2.4' ||
-          steps.patch_bumper.outputs.next_dev_iteration != '1.2.5.dev'
+          steps.patch_bumper.outputs.next_dev_iteration != '1.2.5.dev' ||
+          steps.bumper.outputs.major_part != '1' ||
+          steps.bumper.outputs.minor_part != '2' ||
+          steps.bumper.outputs.patch_part != '4' ||
+          steps.bumper.outputs.patch_next_dev != '5.dev'
         uses: actions/github-script@v5
         with:
           script: core.setFailed('patch bump not working correctly')
@@ -92,7 +96,11 @@ jobs:
       - name: Verify minor bump
         if: >
           steps.minor_bumper.outputs.new_version != '1.3.0' ||
-          steps.minor_bumper.outputs.next_dev_iteration != '1.3.1.dev'
+          steps.minor_bumper.outputs.next_dev_iteration != '1.3.1.dev' ||
+          steps.bumper.outputs.major_part != '1' ||
+          steps.bumper.outputs.minor_part != '3' ||
+          steps.bumper.outputs.patch_part != '0' ||
+          steps.bumper.outputs.patch_next_dev != '1.dev'
         uses: actions/github-script@v5
         with:
           script: core.setFailed('minor bump not working correctly')
@@ -115,7 +123,11 @@ jobs:
       - name: Verify major bump
         if: >
           steps.major_bumper.outputs.new_version != '2.0.0' ||
-          steps.major_bumper.outputs.next_dev_iteration != '2.0.1.dev'
+          steps.major_bumper.outputs.next_dev_iteration != '2.0.1.dev' ||
+          steps.bumper.outputs.major_part != '2' ||
+          steps.bumper.outputs.minor_part != '0' ||
+          steps.bumper.outputs.patch_part != '0' ||
+          steps.bumper.outputs.patch_next_dev != '1.dev'
         uses: actions/github-script@v5
         with:
           script: core.setFailed('major bump not working correctly')

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Verify patch bump
         if: >
           steps.bumper.outputs.new_version != '1.0.0' ||
-          steps.bumper.outputs.next_dev_iteration != '1.0.1.tst'
+          steps.bumper.outputs.next_dev_iteration != '1.0.1.tst' ||
+          steps.bumper.outputs.major_part != '1' ||
+          steps.bumper.outputs.minor_part != '0' ||
+          steps.bumper.outputs.patch_part != '0' ||
+          steps.bumper.outputs.patch_next_dev != '1.tst'
         uses: actions/github-script@v5
         with:
           script: core.setFailed('bump not working correctly')

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ identified from [commit messages][3]:
 
 | Bump  | new_version | next_dev_iteration | changelog filename |
 | :---- | :---------: | :----------------: | :----------------- |
-| major | 3.0.0       | 3.0.1.dev          | changelog-3.0.0.md |
-| minor | 2.2.0       | 2.2.1.dev          | changelog-2.2.0.md |
-| patch | 2.1.7       | 2.1.8.dev          | changelog-2.1.7.md |
+| major |    3.0.0    |     3.0.1.dev      | changelog-3.0.0.md |
+| minor |    2.2.0    |     2.2.1.dev      | changelog-2.2.0.md |
+| patch |    2.1.7    |     2.1.8.dev      | changelog-2.1.7.md |
 
 ## Full usage example
 
@@ -70,7 +70,7 @@ identified from [commit messages][3]:
 | `major_version`      | The next major version         | `1`         |
 | `minor_version`      | The next minor version         | `2`         |
 | `patch_version`      | The next patch version         | `3`         |
-| `patch_version_dev`  | The next development patch     | `4.dev`     |
+| `patch_next_dev`     | The next development patch     | `4.dev`     |
 
 > If `changelog` is set to `true`, a file named `changelog-1.2.3.md` will be created,</br>
 > from which you can source your release notes or updated your changelog.
@@ -86,6 +86,7 @@ Here are a couple of projects of mine, using this action:
 
 <!-- editorconfig-checker-disable -->
 <!-- Real links -->
+
 [0]: https://github.com/TomerFi/version-bumper-action/actions/workflows/stage.yml
 [1]: https://hub.docker.com/r/tomerfi/version-bumper
 [2]: https://semver.org/
@@ -95,7 +96,10 @@ Here are a couple of projects of mine, using this action:
 [6]: https://github.com/TomerFi/switcher_webapi/blob/dev/.github/workflows/release.yml
 [7]: https://github.com/TomerFi/alexa-skills-tester/blob/master/.github/workflows/release.yml
 [8]: https://github.com/TomerFi/version-bumper-action/blob/master/.github/workflows/release.yml
+
 <!-- Badge links -->
+
 [conventional-commits]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
 [gh-build-status]: https://github.com/TomerFi/version-bumper-action/actions/workflows/stage.yml/badge.svg
+
 <!-- editorconfig-checker-enable -->

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ identified from [commit messages][3]:
 | `major_version`      | The next major version         | `1`         |
 | `minor_version`      | The next minor version         | `2`         |
 | `patch_version`      | The next patch version         | `3`         |
+| `patch_version_dev`  | The next development patch     | `4.dev`     |
 
 > If `changelog` is set to `true`, a file named `changelog-1.2.3.md` will be created,</br>
 > from which you can source your release notes or updated your changelog.

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ identified from [commit messages][3]:
 
 ## Outputs
 
-| Key                  | Description                    | Example     |
-| -------------------- | ------------------------------ | ----------- |
-| `new_version`        | The next semantic version      | `1.2.3`     |
-| `next_dev_iteration` | The next development iteration | `1.2.4.dev` |
-| `major_version`      | The next major version         | `1`         |
-| `minor_version`      | The next minor version         | `2`         |
-| `patch_version`      | The next patch version         | `3`         |
-| `patch_next_dev`     | The next development patch     | `4.dev`     |
+| Key                  | Description                                 | Example     |
+| -------------------- | ------------------------------------------- | ----------- |
+| `new_version`        | The next semantic version                   | `1.2.3`     |
+| `next_dev_iteration` | The next development iteration              | `1.2.4.dev` |
+| `major_part`         | The major part of the next version          | `1`         |
+| `minor_part`         | The minor part of the next version          | `2`         |
+| `patch_part`         | The patch part of the next version          | `3`         |
+| `patch_next_dev`     | The patch part of the development iteration | `4.dev`     |
 
 > If `changelog` is set to `true`, a file named `changelog-1.2.3.md` will be created,</br>
 > from which you can source your release notes or updated your changelog.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ identified from [commit messages][3]:
 | -------------------- | ------------------------------ | ----------- |
 | `new_version`        | The next semantic version      | `1.2.3`     |
 | `next_dev_iteration` | The next development iteration | `1.2.4.dev` |
+| `major_version`      | The next major version         | `1`         |
+| `minor_version`      | The next minor version         | `2`         |
+| `patch_version`      | The next patch version         | `3`         |
 
 > If `changelog` is set to `true`, a file named `changelog-1.2.3.md` will be created,</br>
 > from which you can source your release notes or updated your changelog.

--- a/action.sh
+++ b/action.sh
@@ -15,6 +15,13 @@
 output=$(/usr/local/scripts/entrypoint.sh --changelog $1 --preset $2 --label $3 --repopath $4)
 # split output members from the variable
 read new_version next_dev_iteration <<<$(cut -f1,2 -d" " <<<$output)
+# split out major, minor, patch versions
+read major_version <<<$(cut -f1 -d"." <<<"$new_version")
+read minor_version <<<$(cut -f2 -d"." <<<"$new_version")
+read patch_version <<<$(cut -f3 -d"." <<<"$new_version")
 # set action outputs
 echo "::set-output name=new_version::$new_version"
 echo "::set-output name=next_dev_iteration::$next_dev_iteration"
+echo "::set-output name=major_version::$major_version"
+echo "::set-output name=minor_version::$minor_version"
+echo "::set-output name=patch_version::$patch_version"

--- a/action.sh
+++ b/action.sh
@@ -19,9 +19,11 @@ read new_version next_dev_iteration <<<$(cut -f1,2 -d" " <<<$output)
 read major_version <<<$(cut -f1 -d"." <<<"$new_version")
 read minor_version <<<$(cut -f2 -d"." <<<"$new_version")
 read patch_version <<<$(cut -f3 -d"." <<<"$new_version")
+patch_version_dev="$((patch_version+1)).dev"
 # set action outputs
 echo "::set-output name=new_version::$new_version"
 echo "::set-output name=next_dev_iteration::$next_dev_iteration"
 echo "::set-output name=major_version::$major_version"
 echo "::set-output name=minor_version::$minor_version"
 echo "::set-output name=patch_version::$patch_version"
+echo "::set-output name=patch_version_dev::$patch_version_dev"

--- a/action.sh
+++ b/action.sh
@@ -19,7 +19,7 @@ read new_version next_dev_iteration <<<$(cut -f1,2 -d" " <<<$output)
 read major_version <<<$(cut -f1 -d"." <<<"$new_version")
 read minor_version <<<$(cut -f2 -d"." <<<"$new_version")
 read patch_version <<<$(cut -f3 -d"." <<<"$new_version")
-patch_next_dev="$((patch_version+1)).dev"
+read patch_next_dev <<<$(cut -f3- -d"." <<<"$next_dev_iteration")
 # set action outputs
 echo "::set-output name=new_version::$new_version"
 echo "::set-output name=next_dev_iteration::$next_dev_iteration"

--- a/action.sh
+++ b/action.sh
@@ -19,11 +19,11 @@ read new_version next_dev_iteration <<<$(cut -f1,2 -d" " <<<$output)
 read major_version <<<$(cut -f1 -d"." <<<"$new_version")
 read minor_version <<<$(cut -f2 -d"." <<<"$new_version")
 read patch_version <<<$(cut -f3 -d"." <<<"$new_version")
-patch_version_dev="$((patch_version+1)).dev"
+patch_next_dev="$((patch_version+1)).dev"
 # set action outputs
 echo "::set-output name=new_version::$new_version"
 echo "::set-output name=next_dev_iteration::$next_dev_iteration"
 echo "::set-output name=major_version::$major_version"
 echo "::set-output name=minor_version::$minor_version"
 echo "::set-output name=patch_version::$patch_version"
-echo "::set-output name=patch_version_dev::$patch_version_dev"
+echo "::set-output name=patch_next_dev::$patch_next_dev"

--- a/action.sh
+++ b/action.sh
@@ -16,14 +16,14 @@ output=$(/usr/local/scripts/entrypoint.sh --changelog $1 --preset $2 --label $3 
 # split output members from the variable
 read new_version next_dev_iteration <<<$(cut -f1,2 -d" " <<<$output)
 # split out major, minor, patch versions
-read major_version <<<$(cut -f1 -d"." <<<"$new_version")
-read minor_version <<<$(cut -f2 -d"." <<<"$new_version")
-read patch_version <<<$(cut -f3 -d"." <<<"$new_version")
+read major_part <<<$(cut -f1 -d"." <<<"$new_version")
+read minor_part <<<$(cut -f2 -d"." <<<"$new_version")
+read patch_part <<<$(cut -f3 -d"." <<<"$new_version")
 read patch_next_dev <<<$(cut -f3- -d"." <<<"$next_dev_iteration")
 # set action outputs
 echo "::set-output name=new_version::$new_version"
 echo "::set-output name=next_dev_iteration::$next_dev_iteration"
-echo "::set-output name=major_version::$major_version"
-echo "::set-output name=minor_version::$minor_version"
-echo "::set-output name=patch_version::$patch_version"
+echo "::set-output name=major_part::$major_part"
+echo "::set-output name=minor_part::$minor_part"
+echo "::set-output name=patch_part::$patch_part"
 echo "::set-output name=patch_next_dev::$patch_next_dev"

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,12 @@ outputs:
     description: The next semantic version
   next_dev_iteration:
     description: The next development iteration
+  major_version:
+    description: The next major version
+  minor_version:
+    description: The next minor version
+  patch_version:
+    description: The next patch version
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,8 @@ outputs:
     description: The next minor version
   patch_version:
     description: The next patch version
+  patch_version_dev:
+    description: The next development patch version
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,14 @@ outputs:
     description: The next semantic version
   next_dev_iteration:
     description: The next development iteration
-  major_version:
-    description: The next major version
-  minor_version:
-    description: The next minor version
-  patch_version:
-    description: The next patch version
+  major_part:
+    description: The major part of the next version
+  minor_part:
+    description: The minor part of the next version
+  patch_part:
+    description: The patch part of the next version
   patch_next_dev:
-    description: The next development patch version
+    description: The patch part of the development iteration
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
     description: The next minor version
   patch_version:
     description: The next patch version
-  patch_version_dev:
+  patch_next_dev:
     description: The next development patch version
 runs:
   using: docker


### PR DESCRIPTION
# Description

Added outputs for major_version, minor_version and patch_version to use in workflows i.e. tagging image, code, action versions available at multiple non breaking versions: v1, v1.2, v1.2.3. README updated to reflect the changes in the action.sh.


