### PR TITLE
chore: remove deprecated actions syntax

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -21,9 +21,9 @@ read minor_part <<<$(cut -f2 -d"." <<<"$new_version")
 read patch_part <<<$(cut -f3 -d"." <<<"$new_version")
 read patch_next_dev <<<$(cut -f3- -d"." <<<"$next_dev_iteration")
 # set action outputs
-echo "::set-output name=new_version::$new_version"
-echo "::set-output name=next_dev_iteration::$next_dev_iteration"
-echo "::set-output name=major_part::$major_part"
-echo "::set-output name=minor_part::$minor_part"
-echo "::set-output name=patch_part::$patch_part"
-echo "::set-output name=patch_next_dev::$patch_next_dev"
+echo "new_version=$new_version" >> $GITHUB_OUTPUT
+echo "next_dev_iteration=$next_dev_iteration" >> $GITHUB_OUTPUT
+echo "major_part=$major_part" >> $GITHUB_OUTPUT
+echo "minor_part=$minor_part" >> $GITHUB_OUTPUT
+echo "patch_part=$patch_part" >> $GITHUB_OUTPUT
+echo "patch_next_dev=$patch_next_dev" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix deprecated syntax according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- markdownlint-disable MD041-->
## Description

Updated the deprecated "set-output" GitHub actions syntax according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ .

**Related issue (if any):** fixes #34 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

I've just committed my changes, but I'm not really able to test the action myself. Can you take a look at it and might test if everything works fine as well?

In your example, the $GITHUB_OUTPUT variable is inside quotation marks but I think this is not necessary according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and https://github.com/orgs/community/discussions/36617 . If you prefer putting it inside quotation marks then please let me know and I'll change it.

