### PR TITLE
ci: harden workflows and follow best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     name: Lint action and workflows
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@e0207a28405ecad11953ba625a95d92f7889572a  # v1
         with:
           actionlint_flags: -shellcheck= -pyflakes=
 

--- a/.github/workflows/new_version_bumper.yml
+++ b/.github/workflows/new_version_bumper.yml
@@ -29,7 +29,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup SSH signing
-        id: signing
         run: |
           KEY_PATH="$RUNNER_TEMP/signing_key"
           echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
@@ -37,12 +36,6 @@ jobs:
           git config gpg.format ssh
           git config user.signingkey "$KEY_PATH"
           git config commit.gpgsign true
-          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
-
-      - name: Cleanup SSH key
-        if: always()
-        continue-on-error: true
-        run: rm -f "${{ steps.signing.outputs.key_path }}"
 
       - name: get new version
         id: new_version

--- a/.github/workflows/new_version_bumper.yml
+++ b/.github/workflows/new_version_bumper.yml
@@ -29,13 +29,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup SSH signing
+        id: signing
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          KEY_PATH="$RUNNER_TEMP/signing_key"
+          echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey "$KEY_PATH"
           git config commit.gpgsign true
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Cleanup SSH key
+        if: always()
+        continue-on-error: true
+        run: rm -f "${{ steps.signing.outputs.key_path }}"
 
       - name: get new version
         id: new_version

--- a/.github/workflows/new_version_bumper.yml
+++ b/.github/workflows/new_version_bumper.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: |
-            const repo_name = context.payload.repository.full_name
-            const response = await github.request('POST /repos/' + repo_name + '/releases', {
+            const response = await github.rest.repos.createRelease({
+              ...context.repo,
               tag_name: '${{ steps.bumper.outputs.next }}',
               name: '${{ steps.release_name.outputs.value }}',
               generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup SSH signing
-        id: signing
         run: |
           KEY_PATH="$RUNNER_TEMP/signing_key"
           echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
@@ -77,12 +76,6 @@ jobs:
           git config gpg.format ssh
           git config user.signingkey "$KEY_PATH"
           git config commit.gpgsign true
-          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
-
-      - name: Cleanup SSH key
-        if: always()
-        continue-on-error: true
-        run: rm -f "${{ steps.signing.outputs.key_path }}"
 
       - name: Push modifications
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,9 @@ jobs:
             core.setOutput('html_url', response.data.html_url)
 
       - name: Update usage example
-        run: >
-          sed -i
-          's/uses\: tomerfi\/version-bumper-action@.*/uses\: tomerfi\/version-bumper-action@${{ steps.bumper.outputs.next }}/g'
-          README.md
+        run: |
+          version="${{ steps.bumper.outputs.next }}"
+          sed -i "s|uses: tomerfi/version-bumper-action@.*|uses: tomerfi/version-bumper-action@$version|" README.md
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     name: Release new version
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: |
             const repo_name = context.payload.repository.full_name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup SSH signing
+        id: signing
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          KEY_PATH="$RUNNER_TEMP/signing_key"
+          echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey "$KEY_PATH"
           git config commit.gpgsign true
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Cleanup SSH key
+        if: always()
+        continue-on-error: true
+        run: rm -f "${{ steps.signing.outputs.key_path }}"
 
       - name: Push modifications
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         default: "auto"
         required: true
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Configure git
         run: |
@@ -57,7 +57,7 @@ jobs:
           steps.patch_bumper.outputs.minor_part != '2' ||
           steps.patch_bumper.outputs.patch_part != '4' ||
           steps.patch_bumper.outputs.dev_patch_part != '5-dev'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('patch bump not working correctly')
 
@@ -88,7 +88,7 @@ jobs:
           steps.minor_bumper.outputs.minor_part != '3' ||
           steps.minor_bumper.outputs.patch_part != '0' ||
           steps.minor_bumper.outputs.dev_patch_part != '1-beta2'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('minor bump not working correctly')
 
@@ -120,7 +120,7 @@ jobs:
           steps.major_bumper.outputs.minor_part != '0' ||
           steps.major_bumper.outputs.patch_part != '0' ||
           steps.major_bumper.outputs.dev_patch_part != '1-dev'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('major bump not working correctly')
 
@@ -144,7 +144,7 @@ jobs:
           steps.bumper_override.outputs.minor_part != '2' ||
           steps.bumper_override.outputs.patch_part != '4' ||
           steps.bumper_override.outputs.dev_patch_part != '5-dev'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('overriding the bump as a patch bump not working correctly')
 
@@ -170,7 +170,7 @@ jobs:
           steps.manu_patch_bumper.outputs.minor_part != '2' ||
           steps.manu_patch_bumper.outputs.patch_part != '2' ||
           steps.manu_patch_bumper.outputs.dev_patch_part != '3-alpha1'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('manual patch bump not working correctly')
 
@@ -195,7 +195,7 @@ jobs:
           steps.manu_minor_bumper.outputs.minor_part != '3' ||
           steps.manu_minor_bumper.outputs.patch_part != '0' ||
           steps.manu_minor_bumper.outputs.dev_patch_part != '1-dev'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('manual minor bump not working correctly')
 
@@ -220,7 +220,7 @@ jobs:
           steps.manu_major_bumper.outputs.minor_part != '0' ||
           steps.manu_major_bumper.outputs.patch_part != '0' ||
           steps.manu_major_bumper.outputs.dev_patch_part != '1-dev'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: core.setFailed('manual major bump not working correctly')
 

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     name: Test the action
     env:


### PR DESCRIPTION
## Summary

Security hardening and CI best practices across all workflow files:

- Pin all GitHub Actions to full SHA digests to prevent tag manipulation
- Add concurrency control to prevent parallel release conflicts
- Isolate PR concurrency groups to prevent cross-PR cancellation
- Add least-privilege permissions to test job
- Use typed GitHub API for release creation
- Move SSH signing key to $RUNNER_TEMP with explicit cleanup
- Quote sed variable in shell for proper quoting best practices

## Changes per file

- `ci.yml`: PR concurrency isolation, SHA-pin checkout and actionlint
- `release.yml`: SHA-pin actions, concurrency control, typed GitHub API, SSH key cleanup, quote sed variable
- `new_version_bumper.yml`: SHA-pin checkout, SSH key cleanup
- `test_action.yml`: SHA-pin actions, add permissions block