### PR TITLE
fix: remove duplicate Bash Scripting section and useless code block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,6 @@ uvx aicfg link agents --to claude-code --ci
 
 ## Bash Scripting
 
-- **Runtime:** Bash inline scripts in `action.yml`
-- **Package:** `@tomerfi/version-bumper` (pinned via `VB_VERSION` env var)
-- **CI:** GitHub Actions workflows in `.github/workflows/`
-- **Linting:** `actionlint` for workflow/action validation
-
-## Bash Scripting
-
 Bash scripting conventions for action.yml inline scripts.
 
 - Quote all variables: `"$variable"` not `$variable`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,6 @@ The pre-commit hook enforces:
 - **EditorConfig** — editorconfig-checker enforces consistent file formatting
 - **Assistant files** — aicfg keeps project instructions in sync; run `uvx aicfg link agents --to claude-code --ci` to link
 
-```bash
-# Auto-installed by `lefthook install`
-# Runs automatically on every commit (unless on master, which is blocked)
-```
-
 To run checks manually against all files:
 
 ```bash


### PR DESCRIPTION
- Remove duplicate `## Bash Scripting` section in AGENTS.md (leftover Tech Stack content)
- Remove useless empty code block with only comments in CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed duplicate and redundant guidance from the contributor and scripting documentation.
  * Removed outdated notes about automatic commit checks and master-branch restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->